### PR TITLE
Add support for devices with communication code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules/
 
 *.err.log
+.idea

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ const ZKLib = require('./zklib')
 const test = async () => {
 
 
-    let zkInstance = new ZKLib('10.20.0.7', 4370, 10000, 4000);
+    let zkInstance = new ZKLib('10.20.0.7', 4370, 10000, 4000, 1234);
     try {
         // Create socket to machine 
         await zkInstance.createSocket()

--- a/test.js
+++ b/test.js
@@ -2,7 +2,7 @@ const ZKLib = require('./zklib')
 const test = async () => {
 
 
-    let zkInstance = new ZKLib('10.20.0.6', 4370, 10000, 4000);
+    let zkInstance = new ZKLib('192.168.137.201', 4370, 10000, 4000, 1234, 'tcp');
     try {
         // Create socket to machine 
         await zkInstance.createSocket()
@@ -23,7 +23,6 @@ const test = async () => {
 
     const users = await zkInstance.getUsers();
     console.log(users.data)
-
 }
 
 test()

--- a/yarn.lock
+++ b/yarn.lock
@@ -4,5 +4,5 @@
 
 node-zklib@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/node-zklib/-/node-zklib-1.0.0.tgz#5ad7d2169390f33097941acbffccee9fb67df6ec"
+  resolved "https://registry.npmjs.org/node-zklib/-/node-zklib-1.0.0.tgz"
   integrity sha512-zcZe/CI6LP3ObPwC5owNQvDaa6solcNvK6/kodCaisXhc4I0z7mLPn71L9/8pJVCh90YuMjAvv/ENNf4Mrb4vA==

--- a/zklib.js
+++ b/zklib.js
@@ -4,15 +4,16 @@ const ZKLibUDP = require('./zklibudp')
 const { ZKError , ERROR_TYPES } = require('./zkerror')
 
 class ZKLib {
-    constructor(ip, port, timeout , inport){
-        this.connectionType = null
+    constructor(ip, port, timeout , inport, comm_code = 0, protocol){
+        this.connectionType = protocol
 
-        this.zklibTcp = new ZKLibTCP(ip,port,timeout) 
-        this.zklibUdp = new ZKLibUDP(ip,port,timeout , inport) 
+        this.zklibTcp = new ZKLibTCP(ip,port,timeout, comm_code) 
+        this.zklibUdp = new ZKLibUDP(ip,port,timeout , inport, comm_code) 
         this.interval = null 
         this.timer = null
         this.isBusy = false
         this.ip = ip
+        this.comm_code = comm_code || undefined
     }
 
     async functionWrapper (tcpCallback, udpCallback , command ){
@@ -29,7 +30,6 @@ class ZKLib {
                             this.ip
                         ))
                     }
-                       
                 }else{
                     return Promise.reject(new ZKError(
                         new Error( `Socket isn't connected !`),
@@ -78,6 +78,7 @@ class ZKLib {
               
                 try{
                     await this.zklibTcp.connect();
+                    this.zklibTcp.is_connect = true
                     console.log('ok tcp')
                 }catch(err){
                     throw err;

--- a/zklibtcp.js
+++ b/zklibtcp.js
@@ -9,18 +9,24 @@ const { createTCPHeader,
   decodeRecordData40,
   decodeRecordRealTimeLog52,
   checkNotEventTCP,
-  decodeTCPHeader } = require('./utils')
+  decodeTCPHeader,
+  makeCommKey} = require('./utils')
 
-const { log } = require('./helpers/errorLog')
+const { log } = require('./helpers/errorLog');
+const { ZKError } = require('./zkerror');
 
 class ZKLibTCP {
-  constructor(ip, port, timeout) {
+  is_connect = false;
+
+  constructor(ip, port = 4370, timeout = 10000, comm_code = undefined, encoding = 'UTF-8') {
     this.ip = ip
     this.port = port
     this.timeout = timeout
     this.sessionId = null
     this.replyId = 0
     this.socket = null
+    this.comm_code = comm_code
+    this.encoding = encoding
   }
 
 
@@ -55,9 +61,20 @@ class ZKLibTCP {
   connect() {
     return new Promise(async (resolve, reject) => {
       try {
-        const reply = await this.executeCmd(COMMANDS.CMD_CONNECT, '')
-        if (reply) {
+        let reply = await this.executeCmd(COMMANDS.CMD_CONNECT, '')
+        console.log(reply.readUInt16LE(0))
+        if (reply.readUInt16LE(0) === COMMANDS.CMD_ACK_OK) {
           resolve(true)
+        }
+        if (reply.readUInt16LE(0) === COMMANDS.CMD_ACK_UNAUTH) {
+          const hashedCommkey = makeCommKey(this.comm_code, this.sessionId)
+          reply = await this.executeCmd(COMMANDS.CMD_AUTH, hashedCommkey)
+          
+          if (reply.readUInt16LE(0) === COMMANDS.CMD_ACK_OK) {
+            resolve(true)
+          } else {
+            reject(new Error("error de authenticacion", responseCMD))
+          }
         } else {
 
           reject(new Error('NO_REPLY_ON_CMD_CONNECT'))
@@ -170,6 +187,10 @@ class ZKLibTCP {
 
   executeCmd(command, data) {
     return new Promise(async (resolve, reject) => {
+
+      if (![COMMANDS.CMD_CONNECT, COMMANDS.CMD_AUTH].includes(command) && !this.is_connect) {
+        throw new ZKError("instance are not connected")
+      }
 
       if (command === COMMANDS.CMD_CONNECT) {
         this.sessionId = 0

--- a/zklibtcp.js
+++ b/zklibtcp.js
@@ -62,7 +62,7 @@ class ZKLibTCP {
     return new Promise(async (resolve, reject) => {
       try {
         let reply = await this.executeCmd(COMMANDS.CMD_CONNECT, '')
-        console.log(reply.readUInt16LE(0))
+
         if (reply.readUInt16LE(0) === COMMANDS.CMD_ACK_OK) {
           resolve(true)
         }

--- a/zklibudp.js
+++ b/zklibudp.js
@@ -16,7 +16,7 @@ const { MAX_CHUNK, REQUEST_DATA, COMMANDS } = require('./constants')
 const { log } = require('./helpers/errorLog')
 
 class ZKLibUDP {
-  constructor(ip, port, timeout, inport) {
+  constructor(ip, port, timeout, inport, comm_key) {
     this.ip = ip
     this.port = port
     this.timeout = timeout
@@ -24,6 +24,7 @@ class ZKLibUDP {
     this.sessionId = null
     this.replyId = 0
     this.inport = inport
+    this.comm_key = comm_key
   }
 
   createSocket(cbError, cbClose) {


### PR DESCRIPTION
## Add support for devices with communication code

tested and functional with device ZKTeco F22. Only tested with TCP protocol. i ported to javascript the function that hashes the key, from the fananimi/zkpy library, and send the packet in the data field after receiving CMD_ACK_UNAUTH. i also tested the ported version of the function from de ZKteco4J (java) and worked Ok too, despite the two methods gives different codes. the faninimi/zkpy gives always the same hash, but in the other hand, ZKteco4J always change, so i think this last would be the better solution for security concerns.
