### PR TITLE
feat: added setTime function; added inOutStatus in zklibTCP getAttendances and getRealTimeLogs

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -72,14 +72,14 @@ module.exports.createTCPHeader = (command , sessionId, replyId, data)=>{
   
     buf.writeUInt16LE(command, 0);
     buf.writeUInt16LE(0, 2);
-
+  
     buf.writeUInt16LE(sessionId, 4);
     buf.writeUInt16LE(replyId, 6);
     dataBuffer.copy(buf, 8);
     
     const chksum2 = createChkSum(buf);
     buf.writeUInt16LE(chksum2, 2);
-
+      
     replyId = (replyId + 1) % USHRT_MAX;
     buf.writeUInt16LE(replyId, 6);
     
@@ -152,6 +152,7 @@ module.exports.decodeRecordData40 = (recordData)=>{
         .split('\0')
         .shift(),
         recordTime: parseTimeToDate(recordData.readUInt32LE(27)),
+        inOutStatus:  recordData[31] === 0 ? 'IN' : 'OUT'
       }
       return record
 }
@@ -170,22 +171,30 @@ module.exports.decodeRecordRealTimeLog18 = (recordData)=>{
     return {userId , attTime}
 }
 
-module.exports.decodeRecordRealTimeLog52 =(recordData)=>{
-  const payload = removeTcpHeader(recordData)
-        
-  const recvData = payload.subarray(8)
+module.exports.decodeRecordRealTimeLog52 = (recordData) => {
+  // Remove TCP Header
+  const payload = removeTcpHeader(recordData);
 
-  const userId = recvData.slice(0 , 9)
-  .toString('ascii')
-  .split('\0')
-  .shift()
-  
+  // Extract relevant data after the TCP header
+  const recvData = payload.subarray(8);
 
-  const attTime = parseHexToTime(recvData.subarray(26,26+6))
+  // Parse userId (first 9 bytes, ASCII encoded, null-terminated)
+  const userId = recvData
+    .slice(0, 9)
+    .toString('ascii')
+    .split('\0')
+    .shift();
 
-  return { userId, attTime}
+  // Parse attendance time from bytes 26 to 31
+  const attTime = parseHexToTime(recvData.subarray(26, 26 + 6));
 
-}
+  // Determine In/Out status from Byte 25
+  const inOutStatus = recvData[25] === 0 ? 'IN' : recvData[25] === 1 ? 'OUT' : 'UNKNOWN';
+
+  // Return the extracted and processed data
+  return { userId, attTime, inOutStatus };
+};
+
 
 module.exports.decodeUDPHeader = (header)=> {
     const commandId = header.readUIntLE(0,2)

--- a/zklib.js
+++ b/zklib.js
@@ -30,6 +30,7 @@ class ZKLib {
                             this.ip
                         ))
                     }
+                       
                 }else{
                     return Promise.reject(new ZKError(
                         new Error( `Socket isn't connected !`),
@@ -168,6 +169,13 @@ class ZKLib {
 			() => this.zklibUdp.getTime()
 		);
 	}
+
+    async setTime(t) {
+        return await this.functionWrapper(
+            () => this.zklibTcp.setTime(t),
+            () => this.zklibUdp.setTime(t)
+        )
+    }
 
     async disableDevice(){
         return await this. functionWrapper(

--- a/zklibtcp.js
+++ b/zklibtcp.js
@@ -438,11 +438,19 @@ class ZKLibTCP {
       }
     }
 
-
-    const RECORD_PACKET_SIZE = 40
+    //Notes on record packet size:
+    //40 for tft and b&w devices (default)
+    //49 for iface devices
+    const RECORD_PACKET_SIZE = recordData.length % 40 !== 0 ? 49 : 40 ;
 
     let recordData = data.data.subarray(4)
     let records = []
+
+    // Ensure the data size aligns with RECORD_PACKET_SIZE
+    if (recordData.length % RECORD_PACKET_SIZE !== 0) {
+        console.warn("Warning: Attendance data may be incomplete or corrupt");
+    }
+
     while (recordData.length >= RECORD_PACKET_SIZE) {
       const record = decodeRecordData40(recordData.subarray(0, RECORD_PACKET_SIZE))
       records.push({ ...record, ip: this.ip })
@@ -457,6 +465,33 @@ class ZKLibTCP {
 		const time = await this.executeCmd(COMMANDS.CMD_GET_TIME, '');
 		return timeParser.decode(time.readUInt32LE(8));
 	}
+
+  async setTime(tm) {
+    try {
+      // Validate the input time
+      if (!(tm instanceof Date) && typeof tm !== 'number') {
+          throw new TypeError('Invalid time parameter. Must be a Date object or a timestamp.');
+      }
+
+      // Convert the input time to a Date object if it's not already
+      const date = (tm instanceof Date) ? tm : new Date(tm);
+
+      // Encode the time into the required format
+      const encodedTime = timeParser.encode(date);
+
+      // Create a buffer and write the encoded time
+      const commandString = Buffer.alloc(32);
+      commandString.writeUInt32LE(encodedTime, 0);
+
+      // Send the command to set the time
+      return await this.executeCmd(COMMANDS.CMD_SET_TIME, commandString);
+    } catch (err) {
+        // Log the error for debugging
+        console.error('Error setting time:', err);
+        // Re-throw the error for the caller to handle
+        throw err;
+    }
+  }
   
   async freeData() {
     return await this.executeCmd(COMMANDS.CMD_FREE_DATA, '')

--- a/zklibtcp.js
+++ b/zklibtcp.js
@@ -438,13 +438,13 @@ class ZKLibTCP {
       }
     }
 
+    let recordData = data.data.subarray(4)
+    let records = []
+
     //Notes on record packet size:
     //40 for tft and b&w devices (default)
     //49 for iface devices
     const RECORD_PACKET_SIZE = recordData.length % 40 !== 0 ? 49 : 40 ;
-
-    let recordData = data.data.subarray(4)
-    let records = []
 
     // Ensure the data size aligns with RECORD_PACKET_SIZE
     if (recordData.length % RECORD_PACKET_SIZE !== 0) {

--- a/zklibudp.js
+++ b/zklibudp.js
@@ -425,6 +425,26 @@ class ZKLibUDP {
 		return timeParser.decode(time.readUInt32LE(8));
 	}
 
+  async setTime(tm) {
+    try {
+        // Create a buffer for the command
+        const commandBuffer = Buffer.alloc(32);
+
+        // Encode the time and write it to the buffer
+        commandBuffer.writeUInt32LE(timeParser.encode(new Date(tm)), 0);
+
+        // Send the command to set the time
+        await this.executeCmd(COMMANDS.CMD_SET_TIME, commandBuffer);
+
+        // Indicate success
+        return true;
+    } catch (err) {
+        // Log and propagate the error
+        console.error('Error setting time:', err);
+        throw err; // Re-throw the error to allow it to be handled by the caller
+    }
+  }
+
   async getInfo() {
     const data = await this.executeCmd(COMMANDS.CMD_GET_FREE_SIZES, '')
     try {


### PR DESCRIPTION
Hi!

I added a few changes:

- Added `setTime` function both TCP and UDP
- Made improvements for the `getAttendances` and `getRealTimeLogs` but only in TCP
  - Improved utils `decodeRecordData40` and `decodeRecordRealTimeLog52` to detect ins and outs 
  (in my setup, 0 is IN and 1 is OUT).  
  - Improved zklibtcp `getAttendances` to auto-determine record packet size from TFT, black & white, and iFace devices 

This is just a small adjustment that I implemented in my TCP setup, implementing realtime and manual downloading of logs with in/out status.
 
I hope this helps enhance the features of node-zklib. 😄  