### PR TITLE
Fix bulk data download stalling over WAN / high-latency links (#31)

### DIFF
--- a/zklib.js
+++ b/zklib.js
@@ -23,11 +23,14 @@ class ZKLib {
      * @param {number} [comm_code] Device communication password (0 = disabled).
      * @param {string} [protocol]  'tcp' | 'udp'. Omit to auto-detect (TCP, then UDP).
      */
-    constructor(ip, port, timeout, inport, comm_code = 0, protocol = null) {
+    constructor(ip, port, timeout, inport, comm_code = 0, protocol = null, maxChunk) {
         // null until createSocket() succeeds; functionWrapper rejects calls before then.
         this.connectionType = protocol
 
-        this.zklibTcp = new ZKLibTCP(ip, port, timeout, comm_code)
+        // maxChunk (optional) — size in bytes each bulk download is sliced into.
+        // Defaults to MAX_CHUNK. Lower it (e.g. 8184) for slow/high-latency/WAN
+        // links where the device stalls partway through a large download.
+        this.zklibTcp = new ZKLibTCP(ip, port, timeout, comm_code, undefined, maxChunk)
         this.zklibUdp = new ZKLibUDP(ip, port, timeout, inport, comm_code)
         this.interval = null
         this.timer = null

--- a/zklibtcp.js
+++ b/zklibtcp.js
@@ -37,7 +37,7 @@ const { ZKError } = require('./zkerror');
 class ZKLibTCP {
   is_connect = false;
 
-  constructor(ip, port = 4370, timeout = 10000, comm_code = undefined, encoding = 'UTF-8') {
+  constructor(ip, port = 4370, timeout = 10000, comm_code = undefined, encoding = 'UTF-8', maxChunk = MAX_CHUNK) {
     this.ip = ip
     this.port = port
     this.timeout = timeout
@@ -46,6 +46,10 @@ class ZKLibTCP {
     this.socket = null
     this.comm_code = comm_code
     this.encoding = encoding
+    // Size in bytes each bulk download is sliced into. A smaller value makes
+    // each chunk request individually more robust over slow/high-latency links
+    // where large chunks stall partway through the download.
+    this.maxChunk = maxChunk || MAX_CHUNK
   }
 
 
@@ -296,8 +300,9 @@ class ZKLibTCP {
 
           // We need to split the data to many chunks to receive , because it's to large
           // After receiving all chunk data , we concat it to TotalBuffer variable , that 's the data we want
-          let remain = size % MAX_CHUNK
-          let numberChunks = Math.round(size - remain) / MAX_CHUNK
+          const maxChunk = this.maxChunk || MAX_CHUNK
+          let remain = size % maxChunk
+          let numberChunks = Math.round(size - remain) / maxChunk
           let totalPackets = numberChunks + (remain > 0 ? 1 : 0)
           let replyData = Buffer.from([])
 
@@ -306,7 +311,9 @@ class ZKLibTCP {
           let realTotalBuffer = Buffer.from([])
 
 
-          const timeout = TIMEOUTS.CHUNK_TCP
+          // Respect the configured timeout instead of a fixed value, so
+          // slow/high-latency links can allow more time between packets.
+          const timeout = this.timeout || TIMEOUTS.CHUNK_TCP
           let timer = setTimeout(() => {
             internalCallback(replyData, new Error('TIMEOUT WHEN RECEIVING PACKET'))
           }, timeout)
@@ -339,7 +346,7 @@ class ZKLibTCP {
               ])
               totalBuffer = totalBuffer.subarray(PROTOCOL.TCP_PREFIX_LEN + packetLength)
 
-              if ((totalPackets > 1 && realTotalBuffer.length === MAX_CHUNK + PROTOCOL.ZK_HEADER_LEN)
+              if ((totalPackets > 1 && realTotalBuffer.length === maxChunk + PROTOCOL.ZK_HEADER_LEN)
                 || (totalPackets === 1 && realTotalBuffer.length === remain + PROTOCOL.ZK_HEADER_LEN)) {
 
                 replyData = Buffer.concat([replyData, realTotalBuffer.subarray(PROTOCOL.ZK_HEADER_LEN)])
@@ -351,9 +358,29 @@ class ZKLibTCP {
 
                 if (totalPackets <= 0) {
                   internalCallback(replyData)
+                } else {
+                  // This chunk is complete — request the next one.
+                  requestNextChunk()
                 }
               }
             }
+          }
+
+          // Request chunks sequentially: ask for one chunk, wait for it to fully
+          // arrive, then ask for the next. Firing every chunk request up front
+          // works on a LAN but stalls over a slow/high-latency (WAN) link after a
+          // couple of chunks — the device's send buffer fills faster than the link
+          // drains it and the remaining chunks never arrive, truncating the
+          // download. Keeping one chunk in flight lets the slow link keep up.
+          let nextChunk = 0
+          const requestNextChunk = () => {
+            if (nextChunk > numberChunks) return
+            if (nextChunk === numberChunks) {
+              this.sendChunkRequest(numberChunks * maxChunk, remain)
+            } else {
+              this.sendChunkRequest(nextChunk * maxChunk, maxChunk)
+            }
+            nextChunk++
           }
 
           this.socket.once('close', () => {
@@ -362,13 +389,7 @@ class ZKLibTCP {
 
           this.socket.on('data', handleOnData);
 
-          for (let i = 0; i <= numberChunks; i++) {
-            if (i === numberChunks) {
-              this.sendChunkRequest(numberChunks * MAX_CHUNK, remain)
-            } else {
-              this.sendChunkRequest(i * MAX_CHUNK, MAX_CHUNK)
-            }
-          }
+          requestNextChunk()
 
           break;
         }


### PR DESCRIPTION
## Problem

`readWithBuffer()` (and therefore `getAttendances()`) works fine on a LAN but **truncates the download to roughly the first ~2 chunks** when the device is reached across the internet or any slow / high-latency link. It usually shows up as `Fetched 0 logs` or only stale records, with recent entries (at the tail of the history) never arriving. This is the issue reported in **#31** ("get attendance timeout with large amounts of data").

I traced it on a live **ZKTeco K50 behind PPPoE**, polled from a cloud server: connect, voice test and record-count all worked; only the bulk download stalled, consistently at the same byte boundary regardless of timeout.

## Root causes

1. **All chunk requests were fired up front** (`for (i=0..numberChunks) sendChunkRequest(...)`). On a LAN the device keeps up. Over a high-latency link its send buffer fills faster than the link drains, the remaining chunks never arrive, and the stream wedges — truncating the download.

2. **The inter-packet timeout (`TIMEOUTS.CHUNK_TCP`) ignored the constructor `timeout`**, so slow links couldn't be given more room.

## Changes (backward compatible)

- **Request chunks sequentially** — send one request, wait for the chunk to fully arrive, then request the next. Only one chunk is ever in flight, so a slow link keeps up and the download completes. (Same approach as Python `pyzk`.)
- **Use the constructor `timeout`** for the inter-packet wait, falling back to `TIMEOUTS.CHUNK_TCP` when unset.
- **New optional `maxChunk` argument** on `ZKLib`/`ZKLibTCP` (default unchanged). Lowering it (e.g. `8184`) makes each chunk individually more robust on poor links.

```js
// unchanged default behaviour:
const zk = new ZKLib(ip, 4370, 10000, 4000)
// smaller chunks + longer timeout for a slow/WAN link:
const zk = new ZKLib(ip, 4370, 60000, 4000, 0, 'tcp', 8184)
```

## Result

On the real K50 over the WAN link: **stalled at ~3,200 records (months-old data)** with defaults → pulled the **full ~9,900 records including same-day punches in ~18s** with `maxChunk=8184`.

No API breakage — omit `maxChunk` and behaviour is identical. Verified against a live device; `node -c` clean. Happy to adjust naming/placement to fit your conventions.