### PR TITLE
fix: parse InOutStatus (punch type) from byte 31 for 40-byte records

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -169,6 +169,7 @@ module.exports.decodeRecordData40 = (recordData)=>{
         .split('\0')
         .shift(),
         recordTime: parseTimeToDate(recordData.readUInt32LE(27)),
+        type: recordData.readUIntLE(31, 1),
       }
       return record
 }


### PR DESCRIPTION
In ZKTeco 40-byte attendance logs, the In/Out status (punch direction) is stored at byte 31. Previously, the library was not reading this status at all for 40-byte packets, leaving the punch type undefined.

By adding the type property and reading it from byte 31, we can correctly extract 
0: Check-In
1: Check-Out
2: Break-Out
3: Break-In
4: Overtime-In
5: Overtime-Out